### PR TITLE
Adding logic for MITRE enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ A simple linter for Sigma rules
 
 ## Description
 
-sigmalint is a command line interface for validating Sigma rules against the Sigma schema.
+sigmalint is a command line interface for validating and enriching Sigma rules against the Sigma schema.
 
 The available arguments are:
 * `--sigmainput` - Path to a directory that comtains Sigma files or to a single Sigma file.
 * `--directory` - Flag for if sigmainput is a directory
 * `--method` - The schema validator that you wish to use (Default: rx)
+* `--mitre` - Enrich Sigma file with MITRE content based off of any MITRE references in `tags`
 
 The available methods are:
 * `rx` - uses PyRx and the Rx schema from the Sigma repo
@@ -32,6 +33,7 @@ Options:
                                [required]
  --directory                  Flag for if sigmainput is a directory
  --method [rx|jsonschema|s2]  Validation method.
+ --mitre                      Enrich Sigma file with MITRE content
  --help                       Show this message and exit.
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyrx==0.*,>=0.3.0
 pytest==5.*,>=5.4.3
 pytest-cov==2.*,>=2.10.0
 pyyaml==5.*,>=5.3.1
+beautifulsoup4==4.*,>=4.9.3

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='Ryan Plas',
     author_email='ryan.plas@stage2sec.com',
     entry_points={"console_scripts": ["sigmalint = sigmalint.sigmalint:cli"]},
-    packages=['sigmalint', 'sigmalint.schema'],
+    packages=['sigmalint', 'sigmalint.schema', 'sigmalint.modules'],
     package_dir={"": "."},
     package_data={},
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     package_data={},
     install_requires=[
         'click==7.*,>=7.1.2', 'jsonschema==3.*,>=3.2.0', 'pyrx==0.*,>=0.3.0',
-        'pyyaml==5.*,>=5.3.1'
+        'pyyaml==5.*,>=5.3.1', 'beautifulsoup4==4.*,>=4.9.3'
     ],
     extras_require={
         "dev": ["pytest==5.*,>=5.4.3", "pytest-cov==2.*,>=2.10.0"]},

--- a/sigmalint/modules/__init__.py
+++ b/sigmalint/modules/__init__.py
@@ -1,0 +1,1 @@
+from .mitre import mitre_pull

--- a/sigmalint/modules/mitre.py
+++ b/sigmalint/modules/mitre.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+from bs4 import BeautifulSoup
+import requests
+import re
+
+def mitre_pull(technique_id):
+  tactics = []
+
+  # Redirect
+  try:
+      url = "https://attack.mitre.org/techniques/{}/".format(str(technique_id))
+      redirect = requests.get(url,allow_redirects=True)
+      redirect_url = re.search('url=/(.*)"',redirect.text) 
+
+      # Technique URL
+      mitre_url = "https://attack.mitre.org/{}/".format(str(redirect_url.group(1)))
+      mitre_request = requests.get(mitre_url,allow_redirects=False)
+      mitre_soup = BeautifulSoup(mitre_request.text,"html.parser")
+
+      # Tactic ID's
+      tactic_id = mitre_soup.find('div', class_='card-data', id='card-tactics').get_text()
+      tactic_id = tactic_id.replace('Tactics:','').replace(' ','').replace('Tactic:\n','').strip("\n") 
+      tactic_id = tactic_id.split(',') 
+      tactics = tactic_id
+  
+      # Sub Techniques
+      sub_techniques_regex = re.search('Sub-technique of(.*?)</a>',mitre_request.text,re.M | re.DOTALL)
+      sub_techniques = sub_techniques_regex.group(1).replace(':&nbsp;','').replace(' ','').strip("\n")
+      sub_techniques = re.sub('<[^>]+>','',sub_techniques)
+      sub_techniques = sub_techniques.replace('\n','')
+
+      return tactics, sub_techniques
+  except:
+      return None, None 

--- a/sigmalint/modules/mitre.py
+++ b/sigmalint/modules/mitre.py
@@ -29,6 +29,9 @@ def mitre_pull(technique_id):
       sub_techniques = re.sub('<[^>]+>','',sub_techniques)
       sub_techniques = sub_techniques.replace('\n','')
 
-      return tactics, sub_techniques
+      # Reference
+      references = "https://attack.mitre.org/techniques/"+str(technique_id)+"/"
+      # Make sure we return technique_id if valid values were returned
+      return tactics, sub_techniques, technique_id, references
   except:
-      return None, None 
+      return None, None, None, None 

--- a/sigmalint/sigmalint.py
+++ b/sigmalint/sigmalint.py
@@ -89,7 +89,7 @@ def cli(sigmainput, directory, method, mitre):
                                 with open(os.path.join(sigmainput, filename), 'w') as f:
                                     yaml.dump(sigma_yaml_list[0], f)
                             except:
-                                click.secho('Unable to parse {}'.format(os.path.join(sigmainput, result['filename'])), fg=color)
+                                click.secho('Unable to parse {}'.format(filename))
 
 
     click.echo('Results:')

--- a/sigmalint/sigmalint.py
+++ b/sigmalint/sigmalint.py
@@ -89,7 +89,7 @@ def cli(sigmainput, directory, method, mitre):
                                 with open(os.path.join(sigmainput, filename), 'w') as f:
                                     yaml.dump(sigma_yaml_list[0], f)
                             except:
-                                click.secho('Unable to parse {}').format(os.path.join(sigmainput, result['filename'])), fg=color)
+                                click.secho('Unable to parse {}'.format(os.path.join(sigmainput, result['filename'])), fg=color)
 
 
     click.echo('Results:')

--- a/sigmalint/sigmalint.py
+++ b/sigmalint/sigmalint.py
@@ -60,31 +60,33 @@ def cli(sigmainput, directory, method, mitre):
                         results.append({'result': result, 'reasons': errors, 'filename': filename})
 
                     if mitre:
-                        for tag in sigma_yaml_list[0]['tags']: 
-                            if len(re.findall(r'(?i)t\d{4}',tag)) > 0:
-                                mitre_id = re.findall(r'(?i)t\d{4}',tag)
-                                mitre_id = mitre_id[0].upper()
-                                tactics, sub_techniques, technique_id, references = mitre_pull(mitre_id) 
-                                ## Prevent multiple writes to file if `mitre` key already exists
-                                if 'mitre' not in sigma_yaml_list[0]:
-                                    sigma_yaml_list[0]['mitre'] = {} 
-                                    sigma_yaml_list[0]['mitre']['tactics'] = [] 
-                                    sigma_yaml_list[0]['mitre']['subTechniques'] = []
-                                    sigma_yaml_list[0]['mitre']['techniqueIds'] = []
-                                    sigma_yaml_list[0]['mitre']['references'] = []
-                                if tactics is not None and sub_techniques is not None and technique_id is not None and references is not None: 
-                                    for tactic in tactics:
-                                        ## Make sure we aren't duplicating
-                                        if tactic not in sigma_yaml_list[0]['mitre']['tactics']:
-                                            sigma_yaml_list[0]['mitre']['tactics'].append(tactic) 
-                                        if sub_techniques not in sigma_yaml_list[0]['mitre']['subTechniques']:
-                                            sigma_yaml_list[0]['mitre']['subTechniques'].append(sub_techniques)
-                                        if technique_id not in sigma_yaml_list[0]['mitre']['techniqueIds']:
-                                            sigma_yaml_list[0]['mitre']['techniqueIds'].append(technique_id)
-                                        if references not in sigma_yaml_list[0]['mitre']['references']:
-                                            sigma_yaml_list[0]['mitre']['references'].append(references)
-                        with open(os.path.join(sigmainput, filename), 'w') as f:
-                          yaml.dump(sigma_yaml_list[0], f)
+                        ## Most mentions of MITRE are currently found in the 'tags' field for Sigma rules
+                        if 'tags' in sigma_yaml_list[0]:
+                            for tag in sigma_yaml_list[0]['tags']: 
+                                if len(re.findall(r'(?i)t\d{4}',tag)) > 0:
+                                    mitre_id = re.findall(r'(?i)t\d{4}',tag)
+                                    mitre_id = mitre_id[0].upper()
+                                    tactics, sub_techniques, technique_id, references = mitre_pull(mitre_id) 
+                                    ## Prevent multiple writes to file if `mitre` key already exists
+                                    if 'mitre' not in sigma_yaml_list[0]:
+                                        sigma_yaml_list[0]['mitre'] = {} 
+                                        sigma_yaml_list[0]['mitre']['tactics'] = [] 
+                                        sigma_yaml_list[0]['mitre']['subTechniques'] = []
+                                        sigma_yaml_list[0]['mitre']['techniqueIds'] = []
+                                        sigma_yaml_list[0]['mitre']['references'] = []
+                                    if tactics is not None and sub_techniques is not None and technique_id is not None and references is not None: 
+                                        for tactic in tactics:
+                                            ## Make sure we aren't duplicating
+                                            if tactic not in sigma_yaml_list[0]['mitre']['tactics']:
+                                                sigma_yaml_list[0]['mitre']['tactics'].append(tactic) 
+                                            if sub_techniques not in sigma_yaml_list[0]['mitre']['subTechniques']:
+                                                sigma_yaml_list[0]['mitre']['subTechniques'].append(sub_techniques)
+                                            if technique_id not in sigma_yaml_list[0]['mitre']['techniqueIds']:
+                                                sigma_yaml_list[0]['mitre']['techniqueIds'].append(technique_id)
+                                            if references not in sigma_yaml_list[0]['mitre']['references']:
+                                                sigma_yaml_list[0]['mitre']['references'].append(references)
+                            with open(os.path.join(sigmainput, filename), 'w') as f:
+                              yaml.dump(sigma_yaml_list[0], f)
 
     click.echo('Results:')
 

--- a/sigmalint/sigmalint.py
+++ b/sigmalint/sigmalint.py
@@ -81,7 +81,7 @@ def cli(sigmainput, directory, method, mitre):
                                             sigma_yaml_list[0]['mitre']['subTechniques'].append(sub_techniques)
                                         if technique_id not in sigma_yaml_list[0]['mitre']['techniqueIds']:
                                             sigma_yaml_list[0]['mitre']['techniqueIds'].append(technique_id)
-                                        if technique_id not in sigma_yaml_list[0]['mitre']['references']:
+                                        if references not in sigma_yaml_list[0]['mitre']['references']:
                                             sigma_yaml_list[0]['mitre']['references'].append(references)
                         with open(os.path.join(sigmainput, filename), 'w') as f:
                           yaml.dump(sigma_yaml_list[0], f)

--- a/sigmalint/sigmalint.py
+++ b/sigmalint/sigmalint.py
@@ -64,19 +64,25 @@ def cli(sigmainput, directory, method, mitre):
                             if len(re.findall(r'(?i)t\d{4}',tag)) > 0:
                                 mitre_id = re.findall(r'(?i)t\d{4}',tag)
                                 mitre_id = mitre_id[0].upper()
-                                tactics, sub_techniques = mitre_pull(mitre_id) 
+                                tactics, sub_techniques, technique_id, references = mitre_pull(mitre_id) 
                                 ## Prevent multiple writes to file if `mitre` key already exists
                                 if 'mitre' not in sigma_yaml_list[0]:
                                     sigma_yaml_list[0]['mitre'] = {} 
                                     sigma_yaml_list[0]['mitre']['tactics'] = [] 
                                     sigma_yaml_list[0]['mitre']['subTechniques'] = []
-                                if tactics is not None and sub_techniques is not None: 
+                                    sigma_yaml_list[0]['mitre']['techniqueIds'] = []
+                                    sigma_yaml_list[0]['mitre']['references'] = []
+                                if tactics is not None and sub_techniques is not None and technique_id is not None and references is not None: 
                                     for tactic in tactics:
                                         ## Make sure we aren't duplicating
                                         if tactic not in sigma_yaml_list[0]['mitre']['tactics']:
                                             sigma_yaml_list[0]['mitre']['tactics'].append(tactic) 
                                         if sub_techniques not in sigma_yaml_list[0]['mitre']['subTechniques']:
                                             sigma_yaml_list[0]['mitre']['subTechniques'].append(sub_techniques)
+                                        if technique_id not in sigma_yaml_list[0]['mitre']['techniqueIds']:
+                                            sigma_yaml_list[0]['mitre']['techniqueIds'].append(technique_id)
+                                        if technique_id not in sigma_yaml_list[0]['mitre']['references']:
+                                            sigma_yaml_list[0]['mitre']['references'].append(references)
                         with open(os.path.join(sigmainput, filename), 'w') as f:
                           yaml.dump(sigma_yaml_list[0], f)
 

--- a/sigmalint/sigmalint.py
+++ b/sigmalint/sigmalint.py
@@ -62,31 +62,35 @@ def cli(sigmainput, directory, method, mitre):
                     if mitre:
                         ## Most mentions of MITRE are currently found in the 'tags' field for Sigma rules
                         if 'tags' in sigma_yaml_list[0]:
-                            for tag in sigma_yaml_list[0]['tags']: 
-                                if len(re.findall(r'(?i)t\d{4}',tag)) > 0:
-                                    mitre_id = re.findall(r'(?i)t\d{4}',tag)
-                                    mitre_id = mitre_id[0].upper()
-                                    tactics, sub_techniques, technique_id, references = mitre_pull(mitre_id) 
-                                    ## Prevent multiple writes to file if `mitre` key already exists
-                                    if 'mitre' not in sigma_yaml_list[0]:
-                                        sigma_yaml_list[0]['mitre'] = {} 
-                                        sigma_yaml_list[0]['mitre']['tactics'] = [] 
-                                        sigma_yaml_list[0]['mitre']['subTechniques'] = []
-                                        sigma_yaml_list[0]['mitre']['techniqueIds'] = []
-                                        sigma_yaml_list[0]['mitre']['references'] = []
-                                    if tactics is not None and sub_techniques is not None and technique_id is not None and references is not None: 
-                                        for tactic in tactics:
-                                            ## Make sure we aren't duplicating
-                                            if tactic not in sigma_yaml_list[0]['mitre']['tactics']:
-                                                sigma_yaml_list[0]['mitre']['tactics'].append(tactic) 
-                                            if sub_techniques not in sigma_yaml_list[0]['mitre']['subTechniques']:
-                                                sigma_yaml_list[0]['mitre']['subTechniques'].append(sub_techniques)
-                                            if technique_id not in sigma_yaml_list[0]['mitre']['techniqueIds']:
-                                                sigma_yaml_list[0]['mitre']['techniqueIds'].append(technique_id)
-                                            if references not in sigma_yaml_list[0]['mitre']['references']:
-                                                sigma_yaml_list[0]['mitre']['references'].append(references)
-                            with open(os.path.join(sigmainput, filename), 'w') as f:
-                              yaml.dump(sigma_yaml_list[0], f)
+                            try:
+                                for tag in sigma_yaml_list[0]['tags']: 
+                                    if len(re.findall(r'(?i)t\d{4}',tag)) > 0:
+                                        mitre_id = re.findall(r'(?i)t\d{4}',tag)
+                                        mitre_id = mitre_id[0].upper()
+                                        tactics, sub_techniques, technique_id, references = mitre_pull(mitre_id) 
+                                        ## Prevent multiple writes to file if `mitre` key already exists
+                                        if 'mitre' not in sigma_yaml_list[0]:
+                                            sigma_yaml_list[0]['mitre'] = {} 
+                                            sigma_yaml_list[0]['mitre']['tactics'] = [] 
+                                            sigma_yaml_list[0]['mitre']['subTechniques'] = []
+                                            sigma_yaml_list[0]['mitre']['techniqueIds'] = []
+                                            sigma_yaml_list[0]['mitre']['references'] = []
+                                        if tactics is not None and sub_techniques is not None and technique_id is not None and references is not None: 
+                                            for tactic in tactics:
+                                                ## Make sure we aren't duplicating
+                                                if tactic not in sigma_yaml_list[0]['mitre']['tactics']:
+                                                    sigma_yaml_list[0]['mitre']['tactics'].append(tactic) 
+                                                if sub_techniques not in sigma_yaml_list[0]['mitre']['subTechniques']:
+                                                    sigma_yaml_list[0]['mitre']['subTechniques'].append(sub_techniques)
+                                                if technique_id not in sigma_yaml_list[0]['mitre']['techniqueIds']:
+                                                    sigma_yaml_list[0]['mitre']['techniqueIds'].append(technique_id)
+                                                if references not in sigma_yaml_list[0]['mitre']['references']:
+                                                    sigma_yaml_list[0]['mitre']['references'].append(references)
+                                with open(os.path.join(sigmainput, filename), 'w') as f:
+                                    yaml.dump(sigma_yaml_list[0], f)
+                            except:
+                                click.secho('Unable to parse {}').format(os.path.join(sigmainput, result['filename'])), fg=color)
+
 
     click.echo('Results:')
 


### PR DESCRIPTION
This adds logic to scrape both attack and sub-technique id's from MITRE when any MITRE id is referenced within the "tags" values.  Community rules will sometimes have the ID referenced, but it would be helpful to also enrich on that.  An entirely new field is created called `mitre`, and will append to the yaml file with the new content.  A sigmac config can then be used to map these new fields and values for enriching sigma generated alerts.

An example rule before:
```
author: Ryan
description: Finds bad stuff
detection:
  condition: selection and not filter
  filter:
    AccountName: ANONYMOUS LOGON
  selection:
  - EventID: 1111
    LogonProcessName: test
    LogonType: 1
falsepositives:
- Administrator activity
- Penetration tests
level: medium
logsource:
  definition: Finds bad stuff
  product: templeOS
  service: security
references:
- https://github.com/
status: stable
tags:
- attack.lateral_movement
- attack.t1075
- attack.T1065
- attack.T1045
title: Finds Bad Stuff
```

The rule after being linted (+'s have been added on new lines for demonstration purposes):

```
author: Ryan
description: Finds bad stuff
detection:
  condition: selection and not filter
  filter:
    AccountName: ANONYMOUS LOGON
  selection:
  - EventID: 1111
    LogonProcessName: test
    LogonType: 1
falsepositives:
- Administrator activity
- Penetration tests
level: medium
logsource:
  definition: Finds bad stuff
  product: templeOS
  service: security
+ mitre:
+  subTechniques:
+  - T1550
+  - T1027
+  tactics:
+  - DefenseEvasion
+  - LateralMovement
references:
- https://github.com/
status: stable
tags:
- attack.lateral_movement
- attack.t1075
- attack.T1065
- attack.T1045
title: Finds Bad Stuff

```

